### PR TITLE
Allow to disable crosshair by server via sending "no crosshair" string in server info to client

### DIFF
--- a/android/app/src/main/cpp/code/cgame/cg_draw.c
+++ b/android/app/src/main/cpp/code/cgame/cg_draw.c
@@ -1883,7 +1883,7 @@ static void CG_DrawCrosshair(void)
 	float		x, y;
 	int			ca;
 
-	if ( !cg_drawCrosshair.integer ) {
+	if ( !cg_drawCrosshair.integer || vr->no_crosshair ) {
 		return;
 	}
 
@@ -1950,7 +1950,7 @@ static void CG_DrawCrosshair3D(void)
 	char rendererinfos[128];
 	refEntity_t ent;
 
-	if ( !cg_drawCrosshair.integer ) {
+	if ( !cg_drawCrosshair.integer || vr->no_crosshair ) {
 		return;
 	}
 

--- a/android/app/src/main/cpp/code/cgame/cg_main.c
+++ b/android/app/src/main/cpp/code/cgame/cg_main.c
@@ -1972,6 +1972,9 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	CG_ShaderStateChanged();
 
 	trap_S_ClearLoopingSounds( qtrue );
+
+	const char *serverinfo = CG_ConfigString( CS_SERVERINFO );
+	vr->no_crosshair = (strcasestr(serverinfo, "nocrosshair") != NULL || strcasestr(serverinfo, "no crosshair") != NULL);
 }
 
 /*

--- a/android/app/src/main/cpp/code/cgame/cg_weapons.c
+++ b/android/app/src/main/cpp/code/cgame/cg_weapons.c
@@ -1722,7 +1722,7 @@ void CG_AddViewWeapon( playerState_t *ps ) {
 	// set up gun position
 	CG_CalculateVRWeaponPosition( hand.origin, angles );
 
-	if (trap_Cvar_VariableValue("vr_lasersight") != 0.0f)
+	if (trap_Cvar_VariableValue("vr_lasersight") != 0.0f && !vr->no_crosshair)
 	{
 		vec3_t forward, end, dir;
 		AngleVectors(angles, forward, NULL, NULL);

--- a/android/app/src/main/cpp/code/game/g_main.c
+++ b/android/app/src/main/cpp/code/game/g_main.c
@@ -515,6 +515,10 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	G_RemapTeamShaders();
 
 	trap_SetConfigstring( CS_INTERMISSION, "" );
+
+	char serverinfo[MAX_INFO_STRING];
+	trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
+	vr->no_crosshair = (strcasestr(serverinfo, "nocrosshair") != NULL || strcasestr(serverinfo, "no crosshair") != NULL);
 }
 
 

--- a/android/app/src/main/cpp/code/vr/vr_clientinfo.h
+++ b/android/app/src/main/cpp/code/vr/vr_clientinfo.h
@@ -19,6 +19,7 @@ typedef struct {
     vrFollowMode_t follow_mode;
     qboolean weapon_select;
     qboolean weapon_select_autoclose;
+    qboolean no_crosshair;
 
     int realign; // used to realign the fake 6DoF playspace in a multiplayer game
 


### PR DESCRIPTION
When set, disables crosshair and laser sight on clients no matter their configuration in options.

- May be set e.g. as part of server name or mod name
- Is case insensitive
- May be set with or without space, i.e "no crosshair" or "nocrosshair"