### PR TITLE
Fix comfort vignette to not be applied when not moving/turning

### DIFF
--- a/android/app/src/main/cpp/code/cgame/cg_draw.c
+++ b/android/app/src/main/cpp/code/cgame/cg_draw.c
@@ -2603,7 +2603,7 @@ static void CG_DrawVignette( void )
 	}
 
 	const float yawDelta = fabsf(vr->clientview_yaw_delta);
-	if (VectorLength(cg.predictedPlayerState.velocity) > 30.0 || (yawDelta > 0 && yawDelta < 20) || (yawDelta > 340))
+	if (VectorLength(cg.predictedPlayerState.velocity) > 30.0 || (yawDelta > 1 && yawDelta < 20) || (yawDelta > 340))
 	{
 		if (currentComfortVignetteValue <  comfortVignetteValue)
 		{


### PR DESCRIPTION
Switch from abs to fabs removed rounding so there was always some non zero value in delta yaw.