### PR TITLE
Android SDK path detection improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build
-android/app/src/main/cpp/code/VrApi/
+android/app/src/main/cpp/code/VrApi
 *.swp
 *tags
 *~

--- a/Makefile.local
+++ b/Makefile.local
@@ -4,18 +4,21 @@ ANDROID_NDK_VERSION=21.1.6352462
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
-    ANDROID_NDK=/opt/AndroidSDK/ndk/$(ANDROID_NDK_VERSION)
+    ANDROID_SDK_ROOT?=/opt/AndroidSDK
+    ANDROID_NDK=$(ANDROID_SDK_ROOT)/ndk/$(ANDROID_NDK_VERSION)
     ANDROID_CC=$(ANDROID_NDK)/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-$(ANDROID_SDK_VERSION)-clang
     ANDROID_CFLAGS=--target=aarch64-linux-$(ANDROID_SDK_VERSION)
     ANDROID_RANLIB=$(ANDROID_NDK)/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ranlib
 else
 ifeq ($(UNAME), Darwin)
-    ANDROID_NDK=~/Library/Android/sdk/ndk/$(ANDROID_NDK_VERSION)
+    ANDROID_SDK_ROOT?=$(HOME)/Library/Android/sdk
+    ANDROID_NDK=$(ANDROID_SDK_ROOT)/ndk/$(ANDROID_NDK_VERSION)
     ANDROID_CC=$(ANDROID_NDK)/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-$(ANDROID_SDK_VERSION)-clang
     ANDROID_CFLAGS=--target=aarch64-linux-$(ANDROID_SDK_VERSION)
     ANDROID_RANLIB=$(ANDROID_NDK)/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android-ranlib
 else
-    ANDROID_NDK=C:/Users/simon/AppData/Local/Android/Sdk/ndk/$(ANDROID_NDK_VERSION)
+    ANDROID_SDK_ROOT?=$(USERPROFILE)/AppData/Local/Android/Sdk
+    ANDROID_NDK=$(ANDROID_SDK_ROOT)/ndk/$(ANDROID_NDK_VERSION)
     ANDROID_CC=$(ANDROID_NDK)/toolchains/llvm/prebuilt/windows-x86_64/bin/clang.exe
     ANDROID_CFLAGS=--target=aarch64-linux-$(ANDROID_SDK_VERSION)
     ANDROID_RANLIB=$(ANDROID_NDK)/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-ranlib.exe


### PR DESCRIPTION
(1)  .gitignore: remove trailing slash from VrApi ignore rule

This allows use of a symlink to the target. It should also ignore directories
for those who choose to copy VrApi.

(2)  Makefile.local picks up ANDROID_SDK_ROOT environment variable, if set.

If not set, it falls back to the original paths:

* `$(USERPROFILE)/AppData/Local/Android/Sdk` on Windows
* `$(HOME)/Library/Android/sdk` on MacOS
* `/opt/AndroidSDK` on Linux

This allows users to dictate which SDK root they'd like to use without making
local modifications.