### PR TITLE
GLSL float precision increased

### DIFF
--- a/android/app/src/main/cpp/code/renderergl2/tr_glsl.c
+++ b/android/app/src/main/cpp/code/renderergl2/tr_glsl.c
@@ -243,7 +243,7 @@ static void GLSL_GetShaderHeader( GLenum shaderType, const GLchar *extra, char *
 	// HACK: abuse the GLSL preprocessor to turn GLSL 1.20 shaders into 1.30 ones
 #ifdef __ANDROID__
 	Q_strcat(dest, size, "#version 300 es\n");
-	Q_strcat(dest, size, "precision mediump float;\n");
+	Q_strcat(dest, size, "precision highp float;\n");
 	if(shaderType == GL_VERTEX_SHADER)
 	{
 		Q_strcat(dest, size, "#define attribute in\n");


### PR DESCRIPTION
An attempt to resolve lightmap issues:
https://cdn.discordapp.com/attachments/934902023508336640/954885701323853934/6cd750a5678c0f7f8e9779163bc2fe6e.png

Tested with https://github.com/lvonasek/ioq3quest/commits/feature_fps_profiler
It seems increasing float precision has no negative impact on performance.