### PR TITLE
Do not use fast-math flag, it leads to lightmap issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ ifeq ($(PLATFORM),android)
   CLIENT_CFLAGS += $(SDL_CFLAGS) -DSDL_DISABLE_IMMINTRIN_H -fno-builtin-cos -fno-builtin-sin
 
   OPTIMIZEVM = -O3 -funroll-loops -fomit-frame-pointer
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = $(OPTIMIZEVM)
 
   HAVE_VM_COMPILED = false
 


### PR DESCRIPTION
As discussed in Discord, the lightmaps work correct in debug builds only.

I found the release builds are compiled additionally with those C flags:  -funroll-loops -fomit-frame-pointer -ffast-math

After removing -ffast-math the lightmaps started working correctly in release builds.