### PR TITLE
Workaround to make in menu player model rendering working

### DIFF
--- a/android/app/src/main/cpp/code/renderergl2/tr_glsl.c
+++ b/android/app/src/main/cpp/code/renderergl2/tr_glsl.c
@@ -243,7 +243,13 @@ static void GLSL_GetShaderHeader( GLenum shaderType, const GLchar *extra, char *
 	// HACK: abuse the GLSL preprocessor to turn GLSL 1.20 shaders into 1.30 ones
 #ifdef __ANDROID__
 	Q_strcat(dest, size, "#version 300 es\n");
-	Q_strcat(dest, size, "precision highp float;\n");
+
+	// HACK: use in main menu medium float precision (to prevent issue with missing models textures)
+	if (Cvar_Get("r_uiFullScreen", "1", 0)->integer)
+		Q_strcat(dest, size, "precision mediump float;\n");
+	else
+		Q_strcat(dest, size, "precision highp float;\n");
+
 	if(shaderType == GL_VERTEX_SHADER)
 	{
 		Q_strcat(dest, size, "#define attribute in\n");


### PR DESCRIPTION
This PR sets GLSL float precision mediump in main menu, in game mode it uses highp precision.

This way we keep curved architecture render correctly and also player model in the main menu.