### PR TITLE
Game pause flow improvements

### DIFF
--- a/android/app/src/main/cpp/code/client/cl_console.c
+++ b/android/app/src/main/cpp/code/client/cl_console.c
@@ -790,7 +790,7 @@ Scroll it up or down
 void Con_RunConsole (void) {
 	// decide on the destination height of the console
 	if ( Key_GetCatcher( ) & KEYCATCH_CONSOLE )
-		con.finalFrac = 0.5;		// half screen
+		con.finalFrac = 0.4;		// half screen
 	else
 		con.finalFrac = 0;				// none visible
 	

--- a/android/app/src/main/cpp/code/vr/vr_renderer.c
+++ b/android/app/src/main/cpp/code/vr/vr_renderer.c
@@ -35,8 +35,28 @@ void APIENTRY VR_GLDebugLog(GLenum source, GLenum type, GLuint id,
 {
 	if (type == GL_DEBUG_TYPE_ERROR || type == GL_DEBUG_TYPE_PERFORMANCE || ENABLE_GL_DEBUG_VERBOSE)
 	{
-		Com_Printf("GL CALLBACK: %s type = 0x%x, severity = 0x%x, message = %s\n",
-			(type == GL_DEBUG_TYPE_ERROR ? "** GL ERROR **" : ""), type, severity, message);
+		char typeStr[128];
+		switch (type) {
+			case GL_DEBUG_TYPE_ERROR: sprintf(typeStr, "ERROR"); break;
+			case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: sprintf(typeStr, "DEPRECATED_BEHAVIOR"); break;
+			case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR: sprintf(typeStr, "UNDEFINED_BEHAVIOR"); break;
+			case GL_DEBUG_TYPE_PORTABILITY: sprintf(typeStr, "PORTABILITY"); break;
+			case GL_DEBUG_TYPE_PERFORMANCE: sprintf(typeStr, "PERFORMANCE"); break;
+			case GL_DEBUG_TYPE_MARKER: sprintf(typeStr, "MARKER"); break;
+			case GL_DEBUG_TYPE_PUSH_GROUP: sprintf(typeStr, "PUSH_GROUP"); break;
+			case GL_DEBUG_TYPE_POP_GROUP: sprintf(typeStr, "POP_GROUP"); break;
+			default: sprintf(typeStr, "OTHER"); break;
+		}
+
+		char severinityStr[128];
+		switch (severity) {
+			case GL_DEBUG_SEVERITY_HIGH: sprintf(severinityStr, "HIGH"); break;
+			case GL_DEBUG_SEVERITY_MEDIUM: sprintf(severinityStr, "MEDIUM"); break;
+			case GL_DEBUG_SEVERITY_LOW: sprintf(severinityStr, "LOW"); break;
+			default: sprintf(severinityStr, "VERBOSE"); break;
+		}
+
+		Com_Printf("[%s] GL issue - %s: %s\n", severinityStr, typeStr, message);
 	}
 }
 

--- a/android/app/src/main/cpp/main.cpp
+++ b/android/app/src/main/cpp/main.cpp
@@ -97,10 +97,10 @@ int main(int argc, char* argv[]) {
 			hasFocus = g_HasFocus;
 			if (!hasFocus && !Cvar_VariableValue ("cl_paused")) {
 				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_ESCAPE, qtrue, 0, NULL );
-				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
+				//Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
 				paused = true;
 			} else if (hasFocus && paused) {
-				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
+				//Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
 				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_ESCAPE, qtrue, 0, NULL );
 				paused = false;
 			}

--- a/android/app/src/main/cpp/main.cpp
+++ b/android/app/src/main/cpp/main.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 extern "C" {
+	#include <client/keycodes.h>
 	#include <qcommon/q_shared.h>
 	#include <qcommon/qcommon.h>
 	#include <vr/vr_base.h>
@@ -28,6 +29,7 @@ extern "C" {
 static JNIEnv* g_Env = NULL;
 static JavaVM* g_JavaVM = NULL;
 static jobject g_ActivityObject = NULL;
+static bool    g_HasFocus = true;
 
 
 extern "C"
@@ -36,6 +38,11 @@ extern "C"
 	{
 		g_ActivityObject = env->NewGlobalRef(thisObject);
     }
+
+	JNIEXPORT void JNICALL Java_com_drbeef_ioq3quest_MainActivity_nativeFocusChanged(JNIEnv *env, jclass clazz, jboolean focus)
+	{
+	    g_HasFocus = focus;
+	}
 
 	JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
 	{
@@ -83,7 +90,22 @@ int main(int argc, char* argv[]) {
 
 	VR_EnterVR(engine, java);
 
+	bool hasFocus = true;
+	bool paused = false;
 	while (1) {
+		if (hasFocus != g_HasFocus) {
+			hasFocus = g_HasFocus;
+			if (!hasFocus && !Cvar_VariableValue ("cl_paused")) {
+				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_ESCAPE, qtrue, 0, NULL );
+				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
+				paused = true;
+			} else if (hasFocus && paused) {
+				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
+				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_ESCAPE, qtrue, 0, NULL );
+				paused = false;
+			}
+		}
+
 		SDL_Event event;
 		while (SDL_PollEvent(&event)) {
 			LOGI("Received SDL Event: %d", event.type);

--- a/android/app/src/main/java/com/drbeef/ioq3quest/MainActivity.java
+++ b/android/app/src/main/java/com/drbeef/ioq3quest/MainActivity.java
@@ -82,6 +82,11 @@ public class MainActivity extends SDLActivity // implements KeyEvent.Callback
 		}
 	}
 
+	@Override
+	public void onWindowFocusChanged(boolean hasFocus) {
+		nativeFocusChanged(hasFocus);
+	}
+
 	public void create() throws IOException {
 		//Make the directories
 		new File("/sdcard/ioquake3Quest/baseq3").mkdirs();
@@ -188,6 +193,7 @@ public class MainActivity extends SDLActivity // implements KeyEvent.Callback
 	}
 
 	public static native void nativeCreate(MainActivity thisObject);
+	public static native void nativeFocusChanged(boolean focus);
 
 	static {
 		System.loadLibrary("main");


### PR DESCRIPTION
SDLAcitivity.onWindowFocusChanged handled incorrectly the focus change causing:
* disconnect when playing in multiplayer
* freezing when the headset fall in sleep
* sound in loop glitch

This overrides the onWindowFocusChanged behaviour and that resolves the problems above. The game code stays active, that's why I implemented game pausing (sending ESC key).