### PR TITLE
Opengl speedup

### DIFF
--- a/android/app/src/main/cpp/code/vr/vr_renderer.c
+++ b/android/app/src/main/cpp/code/vr/vr_renderer.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ENABLE_GL_DEBUG 1
+#define ENABLE_GL_DEBUG 0
 #define ENABLE_GL_DEBUG_VERBOSE 0
 #if ENABLE_GL_DEBUG
 #include <GLES3/gl32.h>


### PR DESCRIPTION
* Some OpenGL buffer clearing was just using GPU time without any memory/visual effect
* Disabling OpenGL debug messages slightly increases the performance (as it does not have to do checks on every call).