### PR TITLE
Geometry detail improved

### DIFF
--- a/android/app/src/main/cpp/code/q3_ui/ui_video.c
+++ b/android/app/src/main/cpp/code/q3_ui/ui_video.c
@@ -741,8 +741,8 @@ static void GraphicsOptions_ApplyChanges( void *unused, int notification )
 	}
 	else
 	{
-		trap_Cvar_SetValue( "r_lodBias", 1 );
-		trap_Cvar_SetValue( "r_subdivisions", 20 );
+		trap_Cvar_SetValue( "r_lodBias", 2 );
+		trap_Cvar_SetValue( "r_subdivisions", 80 );
 	}
 
 	if ( s_graphicsoptions.filter.curvalue )

--- a/android/app/src/main/cpp/code/renderergl2/tr_mesh.c
+++ b/android/app/src/main/cpp/code/renderergl2/tr_mesh.c
@@ -172,6 +172,8 @@ int R_ComputeLOD( trRefEntity_t *ent ) {
 	    int lod = r_lodbias->integer + r_lodbias->integer;
 	    if (lod >= tr.currentModel->numLods)
 	        lod = tr.currentModel->numLods - 1;
+	    if (lod < 0)
+	        lod = 0;
 	    return lod;
 	}
 

--- a/android/app/src/main/cpp/code/renderergl2/tr_mesh.c
+++ b/android/app/src/main/cpp/code/renderergl2/tr_mesh.c
@@ -164,6 +164,17 @@ R_ComputeLOD
 =================
 */
 int R_ComputeLOD( trRefEntity_t *ent ) {
+
+	//HACK: force specific LOD (for VR it fits better)
+	if (1)
+	{
+	    //high -> 0, medium -> 2, low -> 4
+	    int lod = r_lodbias->integer + r_lodbias->integer;
+	    if (lod >= tr.currentModel->numLods)
+	        lod = tr.currentModel->numLods - 1;
+	    return lod;
+	}
+
 	float radius;
 	float flod, lodscale;
 	float projectedRadius;

--- a/android/app/src/main/cpp/code/sdl/sdl_glimp.c
+++ b/android/app/src/main/cpp/code/sdl/sdl_glimp.c
@@ -1105,10 +1105,10 @@ Responsible for doing a swapbuffers
 */
 void GLimp_EndFrame( void )
 {
-	// don't flip if drawing to front buffer
+	//swap window is implemented in VR API, no need to do it here
 	if ( Q_stricmp( r_drawBuffer->string, "GL_FRONT" ) != 0 )
 	{
-		SDL_GL_SwapWindow( SDL_window );
+		//SDL_GL_SwapWindow( SDL_window );
 	}
 
 	if( r_fullscreen->modified )


### PR DESCRIPTION
The LOD computation takes some CPU time and in the end it chooses LOD levels which doesn't look good in VR.

This PR uses r_lodbias to set the LOD level (r_lodbias * 2). Paradoxly rendering_low_lod_model + computing_lod_level is slower than rendering_high_lod_model (at least according to my tests).

Additionally I changed low geometry detail parameters (as they were almost the same like medium geometry detail) and removed SDL call which didn't have any effect. The call reduced FPS by 1 frame.