### PR TITLE
Fast math flag replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,8 +442,11 @@ ifeq ($(PLATFORM),android)
     -fno-builtin-cos -fno-builtin-sin -fPIC -DARCH_STRING=\\\"$(ARCH)\\\"
   CLIENT_CFLAGS += $(SDL_CFLAGS) -DSDL_DISABLE_IMMINTRIN_H -fno-builtin-cos -fno-builtin-sin
 
+  # Flag -ffast-math replacement: https://pspdfkit.com/blog/2021/understanding-fast-math/
+  # Flags -ffp-contract=fast -fno-trapping-math are unused because they are causing lightmap issues
+  OPTIMIZEFASTMATH = -ffinite-math-only -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros
   OPTIMIZEVM = -O3 -funroll-loops -fomit-frame-pointer
-  OPTIMIZE = $(OPTIMIZEVM)
+  OPTIMIZE = $(OPTIMIZEVM) $(OPTIMIZEFASTMATH)
 
   HAVE_VM_COMPILED = false
 


### PR DESCRIPTION
According to https://pspdfkit.com/blog/2021/understanding-fast-math/ the `-ffast-math` flag is an equvalent to there flags together:
```
-ffinite-math-only
-fno-math-errno
-fassociative-math
-freciprocal-math
-fno-signed-zeros
-fno-trapping-math
-ffp-contract=fast
```

Flags `-fno-trapping-math -ffp-contract=fast` break the lightmap rendering. I enabled all the flags above except these two to gain some performance back and still keep lightmaps working correctly.