### PR TITLE
Various fixes

### DIFF
--- a/android/app/src/main/cpp/code/cgame/cg_view.c
+++ b/android/app/src/main/cpp/code/cgame/cg_view.c
@@ -672,7 +672,7 @@ static int CG_CalcViewValues( ) {
 
 	// intermission view
 	static float hmdYaw = 0;
-	if ( ps->pm_type == PM_INTERMISSION ) {
+	if ( (ps->pm_type == PM_INTERMISSION || ps->pm_type == PM_SPECTATOR) && !vr->virtual_screen ) {
 		VectorCopy( ps->origin, cg.refdef.vieworg );
 
 		static vec3_t	mins = { -1, -1, -1 };

--- a/android/app/src/main/cpp/code/vr/vr_input.c
+++ b/android/app/src/main/cpp/code/vr/vr_input.c
@@ -466,6 +466,7 @@ static void IN_VRController( qboolean isRightController, ovrTracking remoteTrack
 
 	if (vr.virtual_screen || cl.snap.ps.pm_type == PM_INTERMISSION)
     {
+        vr.weapon_zoomed = qfalse;
         if (vr.menuCursorX && vr.menuCursorY)
         {
             float yaw;


### PR DESCRIPTION
- Do not move during spectating by turning controller/hmd
- Do not end locked up in weapon zoomed state on level end and in pause menu