### PR TITLE
Controller mapping refactoring

### DIFF
--- a/android/app/src/main/assets/autoexec.cfg
+++ b/android/app/src/main/assets/autoexec.cfg
@@ -14,36 +14,52 @@ set cg_weaponbob 0
 set sv_pure 0
 set sv_master1 "13.36.227.32:27950"
 
-// VR Button mappings - ONLY put overrides of defaults in here, such as alt key mappings
-// set vr_button_map_A ""
+//////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                              //
+//  Custom Button mappings - ONLY put overrides of defaults in here, such as alt key mappings.  //
+//                                                                                              //
+//  Contained sample mapping corresponds to default control schema. Note that by mapping        //
+//  thumbstick diagonals, thumbstick switches to 8-way mode requiring more precise input!       //
+//                                                                                              //
+//  To activate mapping, do not forget to remove "//" (marking commented out / inactive line).  //
+//  Also note that custom mappings will be overridden by defaults until game restart in case    //
+//  controls are changed from in-game menu.                                                     //
+//                                                                                              //
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+// set vr_button_map_A "+moveup"
 // set vr_button_map_A_ALT ""
-// set vr_button_map_B ""
+// set vr_button_map_B "+movedown"
 // set vr_button_map_B_ALT ""
-// set vr_button_map_X ""
+// set vr_button_map_X "+button2"
 // set vr_button_map_X_ALT ""
-// set vr_button_map_Y ""
+// set vr_button_map_Y "+button3"
 // set vr_button_map_Y_ALT ""
-// set vr_button_map_SECONDARYTHUMBSTICK ""
+// set vr_button_map_SECONDARYTHUMBSTICK "+scores"
 // set vr_button_map_SECONDARYTHUMBSTICK_ALT ""
 // set vr_button_map_PRIMARYTHUMBSTICK ""
 // set vr_button_map_PRIMARYTHUMBSTICK_ALT ""
-// set vr_button_map_RTHUMBFORWARD ""
+// set vr_button_map_SECONDARYTRIGGER "+moveup"
+// set vr_button_map_SECONDARYTRIGGER_ALT ""
+// set vr_button_map_PRIMARYTRIGGER "+attack"
+// set vr_button_map_PRIMARYTRIGGER_ALT ""
+// set vr_button_map_SECONDARYGRIP "+weapon_stabilise"
+// set vr_button_map_SECONDARYGRIP_ALT ""
+// set vr_button_map_PRIMARYGRIP "+weapon_select"
+// set vr_button_map_PRIMARYGRIP_ALT ""
+// set vr_button_map_RTHUMBFORWARD "weapnext"
 // set vr_button_map_RTHUMBFORWARD_ALT ""
-// set vr_button_map_RTHUMBFORWARDLEFT ""
-// set vr_button_map_RTHUMBFORWARDLEFT_ALT ""
 // set vr_button_map_RTHUMBFORWARDRIGHT ""
 // set vr_button_map_RTHUMBFORWARDRIGHT_ALT ""
-// set vr_button_map_RTHUMBBACK ""
+// set vr_button_map_RTHUMBRIGHT "turnright"
+// set vr_button_map_RTHUMBRIGHT_ALT ""
+// set vr_button_map_RTHUMBBACKRIGHT ""
+// set vr_button_map_RTHUMBBACKRIGHT_ALT ""
+// set vr_button_map_RTHUMBBACK "weapprev"
 // set vr_button_map_RTHUMBBACK_ALT ""
 // set vr_button_map_RTHUMBBACKLEFT ""
 // set vr_button_map_RTHUMBBACKLEFT_ALT ""
-// set vr_button_map_RTHUMBBACKRIGHT ""
-// set vr_button_map_RTHUMBBACKRIGHT_ALT ""
-// set vr_button_map_SECONDARYTRIGGER ""
-// set vr_button_map_SECONDARYTRIGGER_ALT ""
-// set vr_button_map_PRIMARYTRIGGER ""
-// set vr_button_map_PRIMARYTRIGGER_ALT ""
-// set vr_button_map_SECONDARYGRIP ""
-// set vr_button_map_SECONDARYGRIP_ALT ""
-// set vr_button_map_PRIMARYGRIP "+alt"
-// set vr_button_map_PRIMARYGRIP_ALT ""
+// set vr_button_map_RTHUMBLEFT "turnleft"
+// set vr_button_map_RTHUMBLEFT_ALT ""
+// set vr_button_map_RTHUMBFORWARDLEFT ""
+// set vr_button_map_RTHUMBFORWARDLEFT_ALT ""

--- a/android/app/src/main/cpp/code/q3_ui/ui_controls3.c
+++ b/android/app/src/main/cpp/code/q3_ui/ui_controls3.c
@@ -169,27 +169,15 @@ static void Controls3_MenuEvent( void* ptr, int notification ) {
 					trap_Cvar_Set("vr_button_map_PRIMARYGRIP", "+weapon_select"); // weapon selector
 					trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBFORWARD_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBRIGHT_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", ""); // unmapped
 					break;
 				case 1: // Weapon wheel on thumbstick - all directions as weapon select (useful for HMD wheel)
 					trap_Cvar_Set("vr_button_map_RTHUMBFORWARD", "+weapon_select");
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", "+weapon_select");
 					trap_Cvar_Set("vr_button_map_RTHUMBRIGHT", "+weapon_select");
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", "+weapon_select");
 					trap_Cvar_Set("vr_button_map_RTHUMBBACK", "+weapon_select");
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", "+weapon_select");
 					trap_Cvar_Set("vr_button_map_RTHUMBLEFT", "+weapon_select");
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", "+weapon_select");
 					trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", "+weapon_select");
 					trap_Cvar_Set("vr_button_map_PRIMARYGRIP", "+alt"); // switch to alt layout
 					trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", "turnleft"); // turn left
@@ -200,10 +188,6 @@ static void Controls3_MenuEvent( void* ptr, int notification ) {
 					} else {
 						trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", "weapprev");
 					}
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", "blank"); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", "blank"); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", "blank"); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", "blank"); // unmapped
 					break;
 				default: // Weapon wheel disabled - only prev/next weapon switch is active
 					trap_Cvar_Set("vr_button_map_RTHUMBLEFT", "turnleft"); // turn left
@@ -217,17 +201,9 @@ static void Controls3_MenuEvent( void* ptr, int notification ) {
 					trap_Cvar_Set("vr_button_map_PRIMARYGRIP", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBFORWARD_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBRIGHT_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", ""); // unmapped
 					trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", ""); // unmapped
-					trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", ""); // unmapped
 					break;
 			}
 		}

--- a/android/app/src/main/cpp/code/ui/ui_main.c
+++ b/android/app/src/main/cpp/code/ui/ui_main.c
@@ -3186,27 +3186,15 @@ static void UI_Update(const char *name) {
 				trap_Cvar_Set("vr_button_map_PRIMARYGRIP", "+weapon_select"); // weapon selector
 				trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBFORWARD_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBRIGHT_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", ""); // unmapped
 				break;
 			case 1: // Weapon wheel on thumbstick - all directions as weapon select (useful for HMD wheel)
 				trap_Cvar_Set("vr_button_map_RTHUMBFORWARD", "+weapon_select");
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", "+weapon_select");
 				trap_Cvar_Set("vr_button_map_RTHUMBRIGHT", "+weapon_select");
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", "+weapon_select");
 				trap_Cvar_Set("vr_button_map_RTHUMBBACK", "+weapon_select");
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", "+weapon_select");
 				trap_Cvar_Set("vr_button_map_RTHUMBLEFT", "+weapon_select");
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", "+weapon_select");
 				trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", "+weapon_select");
 				trap_Cvar_Set("vr_button_map_PRIMARYGRIP", "+alt"); // switch to alt layout
 				trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", "turnleft"); // turn left
@@ -3217,10 +3205,6 @@ static void UI_Update(const char *name) {
 				} else {
 					trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", "weapprev");
 				}
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", "blank"); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", "blank"); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", "blank"); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", "blank"); // unmapped
 				break;
 			default: // Weapon wheel disabled - only prev/next weapon switch is active
 				trap_Cvar_Set("vr_button_map_RTHUMBLEFT", "turnleft"); // turn left
@@ -3234,17 +3218,9 @@ static void UI_Update(const char *name) {
 				trap_Cvar_Set("vr_button_map_PRIMARYGRIP", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_PRIMARYTHUMBSTICK", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBFORWARD_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDRIGHT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBRIGHT_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKRIGHT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBBACK_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBBACKLEFT_ALT", ""); // unmapped
 				trap_Cvar_Set("vr_button_map_RTHUMBLEFT_ALT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT", ""); // unmapped
-				trap_Cvar_Set("vr_button_map_RTHUMBFORWARDLEFT_ALT", ""); // unmapped
 				break;
 		}
 	} else if (Q_stricmp(name, "vr_uturn") == 0) {

--- a/android/app/src/main/cpp/code/vr/vr_base.c
+++ b/android/app/src/main/cpp/code/vr/vr_base.c
@@ -124,27 +124,15 @@ void VR_InitCvars( void )
         Cvar_Get ("vr_button_map_PRIMARYGRIP", "+weapon_select", CVAR_ARCHIVE); // weapon selector
         Cvar_Get ("vr_button_map_PRIMARYTHUMBSTICK", "", CVAR_ARCHIVE); // unmapped
        	Cvar_Get ("vr_button_map_RTHUMBFORWARD_ALT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
        	Cvar_Get ("vr_button_map_RTHUMBRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
        	Cvar_Get ("vr_button_map_RTHUMBBACK_ALT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBBACKLEFT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBBACKLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
        	Cvar_Get ("vr_button_map_RTHUMBLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT", "", CVAR_ARCHIVE); // unmapped
-       	Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
     } else if (controlSchema == 1) {
 	    // Weapon wheel on thumbstick - all directions as weapon select (useful for HMD wheel)
 		Cvar_Get ("vr_button_map_RTHUMBFORWARD", "+weapon_select", CVAR_ARCHIVE);
-    	Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT", "+weapon_select", CVAR_ARCHIVE);
     	Cvar_Get ("vr_button_map_RTHUMBRIGHT", "+weapon_select", CVAR_ARCHIVE);
-    	Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT", "+weapon_select", CVAR_ARCHIVE);
     	Cvar_Get ("vr_button_map_RTHUMBBACK", "+weapon_select", CVAR_ARCHIVE);
-    	Cvar_Get ("vr_button_map_RTHUMBBACKLEFT", "+weapon_select", CVAR_ARCHIVE);
     	Cvar_Get ("vr_button_map_RTHUMBLEFT", "+weapon_select", CVAR_ARCHIVE);
-    	Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT", "+weapon_select", CVAR_ARCHIVE);
     	Cvar_Get ("vr_button_map_PRIMARYTHUMBSTICK", "+weapon_select", CVAR_ARCHIVE);
     	Cvar_Get ("vr_button_map_PRIMARYGRIP", "+alt", CVAR_ARCHIVE); // switch to alt layout
         Cvar_Get ("vr_button_map_RTHUMBLEFT_ALT", "turnleft", CVAR_ARCHIVE); // turn left
@@ -155,10 +143,6 @@ void VR_InitCvars( void )
         } else {
             Cvar_Get ("vr_button_map_RTHUMBBACK_ALT", "weapprev", CVAR_ARCHIVE);
         }
-        Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT_ALT", "blank", CVAR_ARCHIVE); // unmapped
-        Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT_ALT", "blank", CVAR_ARCHIVE); // unmapped
-        Cvar_Get ("vr_button_map_RTHUMBBACKLEFT_ALT", "blank", CVAR_ARCHIVE); // unmapped
-        Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT_ALT", "blank", CVAR_ARCHIVE); // unmapped
 	} else {
 		// Weapon wheel disabled - only prev/next weapon switch is active
 		Cvar_Get ("vr_button_map_RTHUMBLEFT", "turnleft", CVAR_ARCHIVE); // turn left
@@ -172,17 +156,9 @@ void VR_InitCvars( void )
 		Cvar_Get ("vr_button_map_PRIMARYGRIP", "", CVAR_ARCHIVE); // unmapped
 		Cvar_Get ("vr_button_map_PRIMARYTHUMBSTICK", "", CVAR_ARCHIVE); // unmapped
 		Cvar_Get ("vr_button_map_RTHUMBFORWARD_ALT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBFORWARDRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
 		Cvar_Get ("vr_button_map_RTHUMBRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBBACKRIGHT_ALT", "", CVAR_ARCHIVE); // unmapped
 		Cvar_Get ("vr_button_map_RTHUMBBACK_ALT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBBACKLEFT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBBACKLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
 		Cvar_Get ("vr_button_map_RTHUMBLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT", "", CVAR_ARCHIVE); // unmapped
-		Cvar_Get ("vr_button_map_RTHUMBFORWARDLEFT_ALT", "", CVAR_ARCHIVE); // unmapped
 	}
 
 	//Remaining button mapping (buttons not affected by schemas)


### PR DESCRIPTION
- Thumbstick input is now evaluated based on angle (more precise)
- Autoswitch between 4-way and 8-way thumbstick mapping based on whether diagonals are mapped or not
- Do not use diagonals in default control schemas (they are not needed with current weapon wheel implementation and it makes default input more tolerant as using 4-way mapping mode does not require so much precise input)
- Update autoexec to be more informative regarding custom input mappings