### PR TITLE
Weapon selector fixes

### DIFF
--- a/android/app/src/main/cpp/code/cgame/cg_weapons.c
+++ b/android/app/src/main/cpp/code/cgame/cg_weapons.c
@@ -1860,6 +1860,11 @@ void CG_DrawWeaponSelect( void ) {
 		return;
 	}
 
+	// don't display when weapon wheel is opened
+	if (vr->weapon_select) {
+		return;
+	}
+
 	color = CG_FadeColor( cg.weaponSelectTime, WEAPON_SELECT_TIME );
 	if ( !color ) {
 		return;
@@ -2114,7 +2119,8 @@ void CG_DrawWeaponSelector( void )
     float thumbstickAxisX = 0.0f;
     float thumbstickAxisY = 0.0f;
 	float a = atan2(vr->thumbstick_location[thumb][0], vr->thumbstick_location[thumb][1]);
-    if (length(vr->thumbstick_location[thumb][0], vr->thumbstick_location[thumb][1]) > 0.95f)
+	float thumbstickValue = length(vr->thumbstick_location[thumb][0], vr->thumbstick_location[thumb][1]);
+    if (thumbstickValue > 0.95f)
     {
         thumbstickAxisX = sinf(a) * 0.95f;
         thumbstickAxisY = cosf(a) * 0.95f;
@@ -2384,12 +2390,13 @@ void CG_DrawWeaponSelector( void )
 	// In case was invoked by thumbstick axis and thumbstick is centered
 	// select weapon (if any selected) and close the selector
 	if (vr->weapon_select_autoclose && frac > 0.25f) {
-	    if (thumbstickAxisX > -0.1f && thumbstickAxisX < 0.1f && thumbstickAxisY > -0.1f && thumbstickAxisY < 0.1f) {
+	    if (thumbstickValue < 0.1f) {
 	        if (selected) {
 	            cg.weaponSelect = cg.weaponSelectorSelection;
 	        }
 	    	vr->weapon_select = qfalse;
             vr->weapon_select_autoclose = qfalse;
+            vr->weapon_select_using_thumbstick = qfalse;
 	    }
 	}
 }

--- a/android/app/src/main/cpp/code/vr/vr_clientinfo.h
+++ b/android/app/src/main/cpp/code/vr/vr_clientinfo.h
@@ -23,6 +23,7 @@ typedef struct {
     vrFollowMode_t follow_mode;
     qboolean weapon_select;
     qboolean weapon_select_autoclose;
+    qboolean weapon_select_using_thumbstick;
     qboolean no_crosshair;
 
     int realign; // used to realign the fake 6DoF playspace in a multiplayer game


### PR DESCRIPTION
- Prevent erratic actions when thumbstick was near threshold
- Prevent weapon wheel to autoclose too early when pushing thumbstick too slow
- Do not allow/prev next weapon switch when weapon wheel is open