### PR TITLE
Black player model texture in player menu fixed

### DIFF
--- a/android/app/src/main/cpp/code/renderergles3/tr_glsl.c
+++ b/android/app/src/main/cpp/code/renderergles3/tr_glsl.c
@@ -1266,6 +1266,13 @@ void GLSL_InitGPUShaders(void)
 		if (glRefConfig.swizzleNormalmap)
 			Q_strcat(extradefines, 1024, "#define SWIZZLE_NORMALMAP\n");
 
+
+		// HACK: use in main menu simple light model (to prevent issue with missing models textures)
+		if (Cvar_Get("r_uiFullScreen", "1", 0)->integer)
+		{
+			Q_strcat(extradefines, 1024, "#define USE_MENU_LIGHT\n");
+		}
+
 		if (lightType)
 		{
 			Q_strcat(extradefines, 1024, "#define USE_LIGHT\n");

--- a/android/app/src/main/pakQ3Q/glsl/lightall_fp.glsl
+++ b/android/app/src/main/pakQ3Q/glsl/lightall_fp.glsl
@@ -515,5 +515,10 @@ void main()
 
 #endif
 
+// HACK: use in main menu simple light model (to prevent issue with missing models textures)
+#if defined(USE_MENU_LIGHT)
+	gl_FragColor.rgb = diffuse.rgb * lightColor;
+#endif
+
 	gl_FragColor.a = alpha;
 }


### PR DESCRIPTION
There was used advanced world lighting in the main menu (probably with undefined uniforms) causing that player model was sometimes black.

This hack disables advanced world lighting in the main menu. This resolves the issue of black texture in player menu.