### PR TITLE
Seacliff storage access issue fixed

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
 	<application
 		android:allowBackup="false"
 		android:fullBackupContent="false"
+		android:requestLegacyExternalStorage="true"
 		android:icon="@mipmap/ic_launcher"
 		android:label="@string/app_name"
 		android:hasCode="true">


### PR DESCRIPTION
This is workaround for storage issue on Android 11+:
https://developer.android.com/about/versions/11/privacy/storage#scoped-storage