### PR TITLE
Improve pause behaviour

### DIFF
--- a/android/app/src/main/cpp/code/vr/vr_base.c
+++ b/android/app/src/main/cpp/code/vr/vr_base.c
@@ -216,6 +216,11 @@ engine_t* VR_GetEngine( void ) {
 	return &vr_engine;
 }
 
+bool VR_isPauseable( void )
+{
+	return (bool)( ( clc.state == CA_ACTIVE) && !Cvar_VariableValue ("cl_paused") );
+}
+
 bool VR_useScreenLayer( void )
 {
 	//intermission is never full screen

--- a/android/app/src/main/cpp/code/vr/vr_base.h
+++ b/android/app/src/main/cpp/code/vr/vr_base.h
@@ -12,6 +12,7 @@ void VR_EnterVR( engine_t* engine, ovrJava java );
 void VR_LeaveVR( engine_t* engine );
 
 engine_t* VR_GetEngine( void );
+bool VR_isPauseable( void );
 bool VR_useScreenLayer( void );
 
 float radians(float deg);

--- a/android/app/src/main/cpp/code/vr/vr_renderer.c
+++ b/android/app/src/main/cpp/code/vr/vr_renderer.c
@@ -341,6 +341,8 @@ void VR_DrawFrame( engine_t* engine ) {
         re.SetVRHeadsetParms(&projectionMatrix, &monoVRMatrix,
                              engine->framebuffers.framebuffers[engine->framebuffers.swapchainIndex]);
 
+		VR_ClearFrameBuffer(engine->framebuffers.framebuffers[engine->framebuffers.swapchainIndex], eyeW, eyeH);
+
 		Com_Frame();
 
 		engine->framebuffers.swapchainIndex = (engine->framebuffers.swapchainIndex + 1) %

--- a/android/app/src/main/cpp/main.c
+++ b/android/app/src/main/cpp/main.c
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]) {
 	while (1) {
 		if (hasFocus != g_HasFocus) {
 			hasFocus = g_HasFocus;
-			if (!hasFocus && !Cvar_VariableValue ("cl_paused")) {
+			if (!hasFocus && VR_isPauseable()) {
 				Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_ESCAPE, qtrue, 0, NULL );
 				//Com_QueueEvent( Sys_Milliseconds(), SE_KEY, K_CONSOLE, qtrue, 0, NULL );
 				paused = true;


### PR DESCRIPTION
* Oculus menu button does not stop map downloading or multiplayer game joining
* Oculus menu button does not quit multiplayer when final score is shown
* Clear framebuffer in 2D (fixes screen glitches if game is paused in spectator mode)