### PR TITLE
Clearing alpha channel of FBO fixes a few menu issues

### DIFF
--- a/android/app/src/main/cpp/code/vr/vr_renderer.c
+++ b/android/app/src/main/cpp/code/vr/vr_renderer.c
@@ -345,6 +345,12 @@ void VR_DrawFrame( engine_t* engine ) {
 
 		Com_Frame();
 
+		// Clear the alpha channel, other way VR API would not transfer the framebuffer fully
+		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+		glClearColor(0.0, 0.0, 0.0, 1.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+		glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
 		engine->framebuffers.swapchainIndex = (engine->framebuffers.swapchainIndex + 1) %
 			engine->framebuffers.swapchainLength;
 


### PR DESCRIPTION
Clearing alpha channel of FBO fixes a few menu issues
* Some player models (e.g. Wrack) are not correctly rendered in player settings
* OpenArena background is not correctly shown