### PR TITLE
Fix a bug that breaks shooting while holding jump button.

### DIFF
--- a/android/app/src/main/cpp/code/cgame/cg_view.c
+++ b/android/app/src/main/cpp/code/cgame/cg_view.c
@@ -768,7 +768,7 @@ static int CG_CalcViewValues( ) {
 			CG_LaserSight(weaponorigin, trace.endpos, colour, 1.0f);
         }
 
-		if (cg.predictedPlayerState.pm_flags == PM_SPECTATOR)
+		if (cg.predictedPlayerState.pm_type == PM_SPECTATOR)
 		{
 			//If spectating, just take the weapon angles directly
 			VectorCopy(weaponangles, vr->calculated_weaponangles);


### PR DESCRIPTION
This is an attempt to upstream a bugfix from Q3VR repo to Quake3Quest.

The problem here is that wrong field is compared with PM_SPECTATOR to test if we're spectating now. Instead of comparing it with `pm_type`, the original code compared it with `pm_flags`, which use different enums (`PMF_...`). Due to lack of strongly-typed enums this was unnoticed. It also unfortunate because `PM_SPECTATOR` gets value 3, which corresponds to `(PMF_DUCKED & PMF_JUMP_HELD)` flags. So if we've jumped (and have not let go of the jump button yet) and _ducked_ on land, this will break aiming logic and projectiles will be fired in a wrong direction.